### PR TITLE
Fix redundant New Payment buttons on mobile payments page

### DIFF
--- a/src/pages/dashboard/DashboardPayments.tsx
+++ b/src/pages/dashboard/DashboardPayments.tsx
@@ -110,7 +110,7 @@ export function DashboardPayments() {
         </div>
         <Link
           to="/dashboard/payments/new"
-          className="inline-flex items-center gap-2 px-4 py-2.5 bg-glow-400 hover:bg-glow-300 active:bg-glow-500 text-surface-900 font-semibold rounded-xl transition-all text-sm"
+          className="hidden md:inline-flex items-center gap-2 px-4 py-2.5 bg-glow-400 hover:bg-glow-300 active:bg-glow-500 text-surface-900 font-semibold rounded-xl transition-all text-sm"
         >
           <Plus className="w-4 h-4" />
           New Payment


### PR DESCRIPTION
Hide the page-level "+ New Payment" button on mobile screens
(hidden md:inline-flex) since the layout navbar already provides
a "+ New" button. The empty state CTA is preserved for when
there are no payments.

https://claude.ai/code/session_011yJrSDnsW8KfuXpSfGf56G